### PR TITLE
feat(mavwrap): use own custom version

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -19,7 +19,7 @@ manifest:
           - littlefs
 
     - name: zephyr-mavlink
-      url: https://github.com/tor1kk/zephyr-mavlink.git
+      url: https://github.com/RedPropulsion/zephyr-mavlink.git
       revision: main
       path: modules/zephyr-mavlink
       submodules: true


### PR DESCRIPTION
This custom mavwrap implementation enables the end user to retrieve snr and rssi statistics.

Closes #49 .